### PR TITLE
Add Warpgate bastion service

### DIFF
--- a/up.sh
+++ b/up.sh
@@ -32,6 +32,7 @@ docker compose -f matter-hub/docker-compose.yaml up -d
 docker compose -f whatsupdocker/docker-compose.yaml up -d
 docker compose -f beszel/docker-compose.yaml up -d
 docker compose -f photoprism/docker-compose.yaml up -d
+docker compose -f warpgate/docker-compose.yaml up -d
 
 docker compose -f opensky/docker-compose.yaml up -d
 docker compose -f piaware/docker-compose.yaml up -d

--- a/up.sh
+++ b/up.sh
@@ -32,7 +32,7 @@ docker compose -f matter-hub/docker-compose.yaml up -d
 docker compose -f whatsupdocker/docker-compose.yaml up -d
 docker compose -f beszel/docker-compose.yaml up -d
 docker compose -f photoprism/docker-compose.yaml up -d
-docker compose -f warpgate/docker-compose.yaml up -d
+# docker compose -f warpgate/docker-compose.yaml up -d  --- Warpgate disabled - unlikely to be of use ---
 
 docker compose -f opensky/docker-compose.yaml up -d
 docker compose -f piaware/docker-compose.yaml up -d

--- a/warpgate/docker-compose.yaml
+++ b/warpgate/docker-compose.yaml
@@ -14,7 +14,7 @@ volumes:
 
 services:
   warpgate:
-    image: ghcr.io/warp-tech/warpgate:0.19.0
+    image: ghcr.io/warp-tech/warpgate:0.19.1
     container_name: warpgate
     hostname: homeauto
     restart: unless-stopped
@@ -22,6 +22,7 @@ services:
       - traefik_proxy
     ports:
       - "2222:2222"   # SSH
+      - "9999:9999"   # HTTP (for testing; Traefik handles external access)
     volumes:
       - warpgate_data:/data
     labels:
@@ -36,9 +37,9 @@ services:
       - traefik.http.routers.warpgate.tls=true
       - traefik.http.routers.warpgate.tls.certresolver=letsencrypt
       - traefik.http.routers.warpgate.tls.domains[0].main=warpgate.viewpoint.house
-      - traefik.http.services.warpgate.loadbalancer.server.port=8888
-      - traefik.http.services.warpgate.loadbalancer.healthcheck.path=/
-      - traefik.http.services.warpgate.loadbalancer.healthcheck.port=8888
+      - traefik.http.services.warpgate.loadbalancer.server.port=9999
+      # - traefik.http.services.warpgate.loadbalancer.healthcheck.path=/
+      # - traefik.http.services.warpgate.loadbalancer.healthcheck.port=9999
       - homepage.group=Infrastructure
       - homepage.name=Warpgate
       - homepage.href=https://warpgate.viewpoint.house

--- a/warpgate/docker-compose.yaml
+++ b/warpgate/docker-compose.yaml
@@ -22,8 +22,6 @@ services:
       - traefik_proxy
     ports:
       - "2222:2222"   # SSH
-      - "33306:33306" # MySQL
-      - "55432:55432" # PostgreSQL
     volumes:
       - warpgate_data:/data
     labels:
@@ -44,7 +42,7 @@ services:
       - homepage.group=Infrastructure
       - homepage.name=Warpgate
       - homepage.href=https://warpgate.viewpoint.house
-      - homepage.description=SSH/HTTP/MySQL/Postgres Bastion
+      - homepage.description=SSH/HTTP Bastion
       - homepage.icon=mdi-shield-lock
       - com.centurylinklabs.watchtower.enable=true
     logging:

--- a/warpgate/docker-compose.yaml
+++ b/warpgate/docker-compose.yaml
@@ -14,7 +14,7 @@ volumes:
 
 services:
   warpgate:
-    image: ghcr.io/warp-tech/warpgate:v0.19.0
+    image: ghcr.io/warp-tech/warpgate:0.19.0
     container_name: warpgate
     hostname: homeauto
     restart: unless-stopped

--- a/warpgate/docker-compose.yaml
+++ b/warpgate/docker-compose.yaml
@@ -1,0 +1,54 @@
+---
+networks:
+  traefik_proxy:
+    external: true
+    name: traefik_traefik_proxy
+
+volumes:
+  warpgate_data:
+    driver: local
+    driver_opts:
+      type: nfs4
+      o: addr=172.24.32.5,rw
+      device: ":/srv/nfs4/docker_nfs/warpgate/"
+
+services:
+  warpgate:
+    image: ghcr.io/warp-tech/warpgate:v0.19.0
+    container_name: warpgate
+    hostname: homeauto
+    restart: unless-stopped
+    networks:
+      - traefik_proxy
+    ports:
+      - "2222:2222"   # SSH
+      - "33306:33306" # MySQL
+      - "55432:55432" # PostgreSQL
+    volumes:
+      - warpgate_data:/data
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.http.routers.warpgate-http.entrypoints=web
+      - traefik.http.routers.warpgate-http.rule=Host(`warpgate.viewpoint.house`)
+      - traefik.http.routers.warpgate-http.middlewares=warpgate-https
+      - traefik.http.middlewares.warpgate-https.redirectscheme.scheme=https
+      - traefik.http.routers.warpgate.rule=Host(`warpgate.viewpoint.house`)
+      - traefik.http.routers.warpgate.entrypoints=websecure
+      - traefik.http.routers.warpgate.tls=true
+      - traefik.http.routers.warpgate.tls.certresolver=letsencrypt
+      - traefik.http.routers.warpgate.tls.domains[0].main=warpgate.viewpoint.house
+      - traefik.http.services.warpgate.loadbalancer.server.port=8888
+      - traefik.http.services.warpgate.loadbalancer.healthcheck.path=/
+      - traefik.http.services.warpgate.loadbalancer.healthcheck.port=8888
+      - homepage.group=Infrastructure
+      - homepage.name=Warpgate
+      - homepage.href=https://warpgate.viewpoint.house
+      - homepage.description=SSH/HTTP/MySQL/Postgres Bastion
+      - homepage.icon=mdi-shield-lock
+      - com.centurylinklabs.watchtower.enable=true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## Summary
Adds Warpgate as a new service to provide SSH, HTTP, MySQL, and PostgreSQL bastion/gateway capabilities.

## Changes
- Created docker-compose.yaml for Warpgate service
- Configured to run on homeauto host
- Uses NFS volume mount for data persistence
- Integrated with Traefik for HTTPS access
- Added to Homepage dashboard (Infrastructure group)
- Enabled Watchtower for automatic updates
- Updated up.sh deployment script to include Warpgate

## Configuration Details
- **Image**: ghcr.io/warp-tech/warpgate:v0.19.0
- **Hostname**: homeauto
- **Exposed Ports**:
  - SSH: 2222
  - HTTP: 8888 (via Traefik at warpgate.viewpoint.house)
  - MySQL: 33306
  - PostgreSQL: 55432
- **Storage**: NFS at 172.24.32.5:/srv/nfs4/docker_nfs/warpgate/

## Testing
- [ ] Initial setup: `docker compose -f warpgate/docker-compose.yaml run warpgate setup`
- [ ] Start service: `docker compose -f warpgate/docker-compose.yaml up -d`
- [ ] Verify HTTPS access at https://warpgate.viewpoint.house
- [ ] Test SSH access on port 2222

## References
- Warpgate GitHub: https://github.com/warp-tech/warpgate
- Warpgate Documentation: https://warpgate.null.page/