### PR TITLE
Add certresolver for Traefik-exposed services

### DIFF
--- a/actual_server/docker-compose.yaml
+++ b/actual_server/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
       - traefik.http.routers.actual.rule=Host(`actual.viewpoint.house`)
       - traefik.http.routers.actual.entrypoints=websecure
       - traefik.http.routers.actual.tls=true
+      - traefik.http.routers.actual.tls.certresolver=letsencrypt
       - homepage.group=Admin
       - homepage.icon=mdi-cloud-upload-outline
       - homepage.name=Actual

--- a/beszel/docker-compose.yaml
+++ b/beszel/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
       - traefik.http.routers.beszel.rule=Host(`beszel.viewpoint.house`)
       - traefik.http.routers.beszel.entrypoints=websecure
       - traefik.http.routers.beszel.tls=true
+      - traefik.http.routers.beszel.tls.certresolver=letsencrypt
       - traefik.http.services.beszel.loadbalancer.server.port=8090
       - traefik.http.services.beszel.loadbalancer.healthcheck.port=8090
       - homepage.group=Monitoring

--- a/calibre/docker-compose.yaml
+++ b/calibre/docker-compose.yaml
@@ -60,11 +60,13 @@ services:
       - traefik.http.routers.calibre.entrypoints=websecure
       - traefik.http.routers.calibre.service=calibre
       - traefik.http.routers.calibre.tls=true
+      - traefik.http.routers.calibre.tls.certresolver=letsencrypt
       - traefik.http.services.calibre.loadbalancer.server.port=8080
       - traefik.http.services.calibre.loadbalancer.healthcheck.port=8080
       - traefik.http.services.calibre.loadbalancer.healthcheck.path=/
 
       - traefik.http.routers.calibre-web-https.tls=true
+      - traefik.http.routers.calibre-web-https.tls.certresolver=letsencrypt
       - traefik.http.routers.calibre-web-https.rule=Host(`calibre-web.viewpoint.house`)
       - traefik.http.routers.calibre-web-https.entrypoints=websecure
       - traefik.http.routers.calibre-web-https.service=calibre-web-https

--- a/double-take/docker-compose.yaml
+++ b/double-take/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
       - traefik.http.routers.double-take.rule=Host(`double-take.viewpoint.house`)
       - traefik.http.routers.double-take.entrypoints=websecure
       - traefik.http.routers.double-take.tls=true
+      - traefik.http.routers.double-take.tls.certresolver=letsencrypt
       - traefik.http.services.double-take.loadbalancer.server.port=3000
       - traefik.http.services.double-take.loadbalancer.healthcheck.path=/
       - traefik.http.services.double-take.loadbalancer.healthcheck.port=3000

--- a/elk-stack/docker-compose.yaml
+++ b/elk-stack/docker-compose.yaml
@@ -54,6 +54,7 @@ services:
       - traefik.http.routers.cerebro.rule=Host(`cerebro.viewpoint.house`)
       - traefik.http.routers.cerebro.entrypoints=websecure
       - traefik.http.routers.cerebro.tls=true
+      - traefik.http.routers.cerebro.tls.certresolver=letsencrypt
       - homepage.group=Monitoring
       - homepage.name=Cerebro
       - homepage.icon=mdi-chip
@@ -75,6 +76,7 @@ services:
       - traefik.http.routers.elastichq.rule=Host(`elastichq.viewpoint.house`)
       - traefik.http.routers.elastichq.entrypoints=websecure
       - traefik.http.routers.elastichq.tls=true
+      - traefik.http.routers.elastichq.tls.certresolver=letsencrypt
       - homepage.group=Monitoring
       - homepage.name=ElasticHQ
       - homepage.icon=mdi-chip
@@ -316,6 +318,7 @@ services:
       - traefik.http.routers.kibana01.rule=Host(`logs.viewpoint.house`)
       - traefik.http.routers.kibana01.entrypoints=websecure
       - traefik.http.routers.kibana01.tls=true
+      - traefik.http.routers.kibana01.tls.certresolver=letsencrypt
       - traefik.http.services.kibana01.loadbalancer.server.port=5601
       - traefik.http.services.kibana01.loadbalancer.healthcheck.path=/
       - traefik.http.services.kibana01.loadbalancer.healthcheck.port=5601

--- a/eplzones/docker-compose.yaml
+++ b/eplzones/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
       - traefik.http.routers.EPLZones.rule=Host(`eplzones.viewpoint.house`)
       - traefik.http.routers.EPLZones.entrypoints=websecure
       - traefik.http.routers.EPLZones.tls=true
+      - traefik.http.routers.EPLZones.tls.certresolver=letsencrypt
       - traefik.http.services.EPLZones.loadbalancer.server.port=42069
       - traefik.http.services.EPLZones.loadbalancer.healthcheck.path=/
       - traefik.http.services.EPLZones.loadbalancer.healthcheck.port=42069

--- a/esphome/docker-compose.yaml
+++ b/esphome/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
       - traefik.http.routers.esphome.rule=Host(`esphome.viewpoint.house`)
       - traefik.http.routers.esphome.entrypoints=websecure
       - traefik.http.routers.esphome.tls=true
+      - traefik.http.routers.esphome.tls.certresolver=letsencrypt
       - traefik.http.services.esphome.loadbalancer.server.port=6052
       - traefik.http.services.esphome.loadbalancer.healthcheck.path=/
       - traefik.http.services.esphome.loadbalancer.healthcheck.port=6052

--- a/fr24feed/docker-compose.yaml
+++ b/fr24feed/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
       - traefik.http.routers.fr24feed.rule=Host(`fr24feed.viewpoint.house`)
       - traefik.http.routers.fr24feed.entrypoints=websecure
       - traefik.http.routers.fr24feed.tls=true
+      - traefik.http.routers.fr24feed.tls.certresolver=letsencrypt
       - traefik.http.services.fr24feed.loadbalancer.server.port=8754
       - traefik.http.services.fr24feed.loadbalancer.healthcheck.path=/
       - traefik.http.services.fr24feed.loadbalancer.healthcheck.port=8754

--- a/frigate/docker-compose.yaml
+++ b/frigate/docker-compose.yaml
@@ -70,6 +70,7 @@ services:
       - traefik.http.routers.frigate.rule=Host(`cctv.viewpoint.house`)
       - traefik.http.routers.frigate.entrypoints=websecure
       - traefik.http.routers.frigate.tls=true
+      - traefik.http.routers.frigate.tls.certresolver=letsencrypt
       - traefik.http.services.frigate.loadbalancer.server.port=5000
       - traefik.http.services.frigate.loadbalancer.healthcheck.path=/
       - traefik.http.services.frigate.loadbalancer.healthcheck.port=5000

--- a/givtcp/docker-compose.yaml
+++ b/givtcp/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
       - traefik.http.routers.givtcp.rule=Host(`givtcp.viewpoint.house`)
       - traefik.http.routers.givtcp.entrypoints=websecure
       - traefik.http.routers.givtcp.tls=true
+      - traefik.http.routers.givtcp.tls.certresolver=letsencrypt
       - traefik.http.services.givtcp.loadbalancer.server.port=8099
       - traefik.http.services.givtcp.loadbalancer.healthcheck.path=/
       - traefik.http.services.givtcp.loadbalancer.healthcheck.port=8099

--- a/grafana/docker-compose.yaml
+++ b/grafana/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
       - traefik.http.routers.grafana.rule=Host(`grafana.viewpoint.house`)
       - traefik.http.routers.grafana.entrypoints=websecure
       - traefik.http.routers.grafana.tls=true
+      - traefik.http.routers.grafana.tls.certresolver=letsencrypt
       - traefik.http.services.grafana.loadbalancer.server.port=3000
       - traefik.http.services.grafana.loadbalancer.healthcheck.path=/
       - traefik.http.services.grafana.loadbalancer.healthcheck.port=3000

--- a/graphs1090/docker-compose.yaml
+++ b/graphs1090/docker-compose.yaml
@@ -53,6 +53,7 @@ services:
       - traefik.http.routers.graphs1090.rule=Host(`graphs1090.viewpoint.house`)
       - traefik.http.routers.graphs1090.entrypoints=websecure
       - traefik.http.routers.graphs1090.tls=true
+      - traefik.http.routers.graphs1090.tls.certresolver=letsencrypt
       - traefik.http.services.graphs1090.loadbalancer.server.port=80
       - traefik.http.services.graphs1090.loadbalancer.healthcheck.path=/
       - traefik.http.services.graphs1090.loadbalancer.healthcheck.port=80

--- a/ha-stack/docker-compose.yaml
+++ b/ha-stack/docker-compose.yaml
@@ -67,6 +67,7 @@ services:
       - traefik.http.routers.hasecure.entrypoints=websecure
       - traefik.http.routers.hasecure.service=ha
       - traefik.http.routers.hasecure.tls=true
+      - traefik.http.routers.hasecure.tls.certresolver=letsencrypt
       - traefik.http.services.hasecure.loadbalancer.server.port=8123
       - traefik.http.services.hasecure.loadbalancer.healthcheck.path=/
       - traefik.http.services.hasecure.loadbalancer.healthcheck.port=8123

--- a/homebox/docker-compose.yaml
+++ b/homebox/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
       - traefik.http.routers.homebox.rule=Host(`parts.viewpoint.house`)
       - traefik.http.routers.homebox.entrypoints=websecure
       - traefik.http.routers.homebox.tls=true
+      - traefik.http.routers.homebox.tls.certresolver=letsencrypt
       - traefik.http.services.homebox.loadbalancer.server.port=7745
       - traefik.http.services.homebox.loadbalancer.healthcheck.port=7745
       - traefik.http.services.homebox.loadbalancer.healthcheck.path=/

--- a/homepage/docker-compose.yaml
+++ b/homepage/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - traefik.http.routers.homepage.rule=Host(`home.viewpoint.house`)
       - traefik.http.routers.homepage.entrypoints=websecure
       - traefik.http.routers.homepage.tls=true
+      - traefik.http.routers.homepage.tls.certresolver=letsencrypt
       - traefik.http.services.homepage.loadbalancer.server.port=3000
       - traefik.http.services.homepage.loadbalancer.healthcheck.path=/
       - traefik.http.services.homepage.loadbalancer.healthcheck.port=3000

--- a/hydra/docker-compose.yaml
+++ b/hydra/docker-compose.yaml
@@ -43,6 +43,7 @@ services:
       - traefik.http.routers.hydra.rule=Host(`hydra.viewpoint.house`)
       - traefik.http.routers.hydra.entrypoints=websecure
       - traefik.http.routers.hydra.tls=true
+      - traefik.http.routers.hydra.tls.certresolver=letsencrypt
       - traefik.http.services.hydra.loadbalancer.server.port=5076
       - traefik.http.services.hydra.loadbalancer.healthcheck.port=5076
       - traefik.http.services.hydra.loadbalancer.healthcheck.path=/

--- a/influxdb/docker-compose.yaml
+++ b/influxdb/docker-compose.yaml
@@ -51,6 +51,7 @@ services:
       - traefik.http.routers.influxdb.rule=Host(`influxdb.viewpoint.house`)
       - traefik.http.routers.influxdb.entrypoints=websecure
       - traefik.http.routers.influxdb.tls=true
+      - traefik.http.routers.influxdb.tls.certresolver=letsencrypt
       - traefik.http.services.influxdb.loadbalancer.server.port=8086
       - traefik.http.services.influxdb.loadbalancer.healthcheck.path=/
       - traefik.http.services.influxdb.loadbalancer.healthcheck.port=8086

--- a/karakeep/docker-compose.yaml
+++ b/karakeep/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
       - traefik.http.routers.karakeep.rule=Host(`karakeep.glasgownet.com`)
       - traefik.http.routers.karakeep.entrypoints=websecure
       - traefik.http.routers.karakeep.tls=true
+      - traefik.http.routers.karakeep.tls.certresolver=letsencrypt
       - traefik.http.services.karakeep.loadbalancer.server.port=3000
       - traefik.http.services.karakeep.loadbalancer.healthcheck.port=3000
       - traefik.http.services.karakeep.loadbalancer.healthcheck.path=/

--- a/miniflux/docker-compose.yaml
+++ b/miniflux/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
       - traefik.http.routers.miniflux.rule=Host(`news.viewpoint.house`)
       - traefik.http.routers.miniflux.entrypoints=websecure
       - traefik.http.routers.miniflux.tls=true
+      - traefik.http.routers.miniflux.tls.certresolver=letsencrypt
       - traefik.http.services.miniflux.loadbalancer.server.port=8080
       # - traefik.http.services.miniflux.loadbalancer.healthcheck.port=8080
       # - traefik.http.services.miniflux.loadbalancer.healthcheck.path=/

--- a/monitoring-stack/docker-compose.yaml
+++ b/monitoring-stack/docker-compose.yaml
@@ -92,6 +92,7 @@ services:
       - traefik.http.routers.librenms.rule=Host(`nms.viewpoint.house`)
       - traefik.http.routers.librenms.entrypoints=websecure
       - traefik.http.routers.librenms.tls=true
+      - traefik.http.routers.librenms.tls.certresolver=letsencrypt
       - traefik.http.services.librenms.loadbalancer.server.port=8000
       # - traefik.http.services.librenms.loadbalancer.healthcheck.port=8000
       # - traefik.http.services.librenms.loadbalancer.healthcheck.path=/
@@ -252,6 +253,7 @@ services:
       - traefik.http.routers.speedtest.rule=Host(`speedtest.viewpoint.house`)
       - traefik.http.routers.speedtest.entrypoints=websecure
       - traefik.http.routers.speedtest.tls=true
+      - traefik.http.routers.speedtest.tls.certresolver=letsencrypt
       - traefik.http.services.speedtest.loadbalancer.server.port=3000
       - traefik.http.services.speedtest.loadbalancer.healthcheck.port=3000
       - traefik.http.services.speedtest.loadbalancer.healthcheck.path=/
@@ -290,6 +292,7 @@ services:
       - traefik.http.routers.smokeping.rule=Host(`smokeping.viewpoint.house`)
       - traefik.http.routers.smokeping.entrypoints=websecure
       - traefik.http.routers.smokeping.tls=true
+      - traefik.http.routers.smokeping.tls.certresolver=letsencrypt
       - traefik.http.services.smokeping.loadbalancer.server.port=80
       - traefik.http.services.smokeping.loadbalancer.healthcheck.port=80
       - traefik.http.services.smokeping.loadbalancer.healthcheck.path=/

--- a/music-assistant/docker-compose.yaml
+++ b/music-assistant/docker-compose.yaml
@@ -47,6 +47,7 @@ services:
       - traefik.http.routers.music.rule=Host(`music.viewpoint.house`)
       - traefik.http.routers.music.entrypoints=websecure
       - traefik.http.routers.music.tls=true
+      - traefik.http.routers.music.tls.certresolver=letsencrypt
       # - traefik.http.services.music.loadbalancer.server.port=8095
       - traefik.http.services.music.loadbalancer.server.url=http://172.24.32.13:8095
       - traefik.http.services.music.loadbalancer.healthcheck.hostname=172.24.32.13

--- a/nautobot/docker-compose.yaml
+++ b/nautobot/docker-compose.yaml
@@ -96,6 +96,7 @@ services:
       - traefik.http.routers.nautobot.rule=Host(`nautobot.viewpoint.house`)
       - traefik.http.routers.nautobot.entrypoints=websecure
       - traefik.http.routers.nautobot.tls=true
+      - traefik.http.routers.nautobot.tls.certresolver=letsencrypt
       - traefik.http.services.nautobot.loadbalancer.server.port=8080
       - traefik.http.services.nautobot.loadbalancer.healthcheck.path=/
       - traefik.http.services.nautobot.loadbalancer.healthcheck.port=8080

--- a/nginx_core/docker-compose.yaml
+++ b/nginx_core/docker-compose.yaml
@@ -43,6 +43,7 @@ services:
       - traefik.http.routers.nginx_core-https.rule=Host(`core.viewpoint.house`)
       - traefik.http.routers.nginx_core-https.entrypoints=websecure
       - traefik.http.routers.nginx_core-https.tls=true
+      - traefik.http.routers.nginx_core-https.tls.certresolver=letsencrypt
       - homepage.group=Management
       - homepage.name=Core Web
       - homepage.href=https://core.viewpoint.house

--- a/node-red/docker-compose.yaml
+++ b/node-red/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       - traefik.http.routers.nodered.rule=Host(`nodered.viewpoint.house`)
       - traefik.http.routers.nodered.entrypoints=websecure
       - traefik.http.routers.nodered.tls=true
+      - traefik.http.routers.nodered.tls.certresolver=letsencrypt
       - traefik.http.services.nodered.loadbalancer.server.port=1880
       - traefik.http.services.nodered.loadbalancer.healthcheck.path=/
       - traefik.http.services.nodered.loadbalancer.healthcheck.port=1880

--- a/nzbget/docker-compose.yaml
+++ b/nzbget/docker-compose.yaml
@@ -52,6 +52,7 @@ services:
       - traefik.http.routers.nzbget.rule=Host(`nzbget.viewpoint.house`)
       - traefik.http.routers.nzbget.entrypoints=websecure
       - traefik.http.routers.nzbget.tls=true
+      - traefik.http.routers.nzbget.tls.certresolver=letsencrypt
       - traefik.http.services.nzbget.loadbalancer.server.port=6789
       # - traefik.http.services.nzbget.loadbalancer.healthcheck.port=6789
       # - traefik.http.services.nzbget.loadbalancer.healthcheck.path=/

--- a/ollama/docker-compose.yaml
+++ b/ollama/docker-compose.yaml
@@ -108,6 +108,7 @@ services:
       - traefik.http.routers.ollama-webui.rule=Host(`ollama.viewpoint.house`)
       - traefik.http.routers.ollama-webui.entrypoints=websecure
       - traefik.http.routers.ollama-webui.tls=true
+      - traefik.http.routers.ollama-webui.tls.certresolver=letsencrypt
       - traefik.http.services.ollama-webui.loadbalancer.server.port=8080
       - traefik.http.services.ollama-webui.loadbalancer.healthcheck.path=/
       - traefik.http.services.ollama-webui.loadbalancer.healthcheck.port=8080

--- a/paperless/docker-compose.yaml
+++ b/paperless/docker-compose.yaml
@@ -94,6 +94,7 @@ services:
       - traefik.http.routers.paperless.rule=Host(`paperless.viewpoint.house`)
       - traefik.http.routers.paperless.entrypoints=websecure
       - traefik.http.routers.paperless.tls=true
+      - traefik.http.routers.paperless.tls.certresolver=letsencrypt
       - traefik.http.services.paperless.loadbalancer.server.port=8000
       # - traefik.http.routers.paperless.middlewares=authelia@docker
       - homepage.group=Media

--- a/peanut/docker-compose.yaml
+++ b/peanut/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
       - traefik.http.routers.peanut.rule=Host(`peanut.viewpoint.house`)
       - traefik.http.routers.peanut.entrypoints=websecure
       - traefik.http.routers.peanut.tls=true
+      - traefik.http.routers.peanut.tls.certresolver=letsencrypt
       - traefik.http.services.peanut.loadbalancer.server.port=8080
       - traefik.http.services.peanut.loadbalancer.healthcheck.port=8080
       - traefik.http.services.peanut.loadbalancer.healthcheck.path=/

--- a/photoprism/docker-compose.yaml
+++ b/photoprism/docker-compose.yaml
@@ -94,6 +94,7 @@ services:
       - traefik.http.routers.photos.rule=Host(`photos.viewpoint.house`)
       - traefik.http.routers.photos.entrypoints=websecure
       - traefik.http.routers.photos.tls=true
+      - traefik.http.routers.photos.tls.certresolver=letsencrypt
       - traefik.http.services.photos.loadbalancer.server.port=2342
       - traefik.http.services.photos.loadbalancer.healthcheck.path=/
       - traefik.http.services.photos.loadbalancer.healthcheck.port=2342

--- a/phpmyadmin/docker-compose.yaml
+++ b/phpmyadmin/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
       - traefik.http.routers.phpmyadmin.rule=Host(`phpmyadmin.viewpoint.house`)
       - traefik.http.routers.phpmyadmin.entrypoints=websecure
       - traefik.http.routers.phpmyadmin.tls=true
+      - traefik.http.routers.phpmyadmin.tls.certresolver=letsencrypt
       - traefik.http.services.phpmyadmin.loadbalancer.server.port=80
       - traefik.http.services.phpmyadmin.loadbalancer.healthcheck.port=80
       - traefik.http.services.phpmyadmin.loadbalancer.healthcheck.path=/

--- a/piaware/docker-compose.yaml
+++ b/piaware/docker-compose.yaml
@@ -47,6 +47,7 @@ services:
       - traefik.http.routers.piaware.rule=Host(`piaware.viewpoint.house`)
       - traefik.http.routers.piaware.entrypoints=websecure
       - traefik.http.routers.piaware.tls=true
+      - traefik.http.routers.piaware.tls.certresolver=letsencrypt
       - traefik.http.services.piaware01.loadbalancer.server.port=8080
       - traefik.http.services.piaware01.loadbalancer.healthcheck.path=/
       - traefik.http.services.piaware01.loadbalancer.healthcheck.port=8080

--- a/pihole/docker-compose.yaml
+++ b/pihole/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
       - traefik.http.middlewares.pihole-https.redirectscheme.scheme=https
       - traefik.http.routers.pihole.rule=Host(`pihole.viewpoint.house`)
       - traefik.http.routers.pihole.tls=true
+      - traefik.http.routers.pihole.tls.certresolver=letsencrypt
       - traefik.http.routers.pihole.entrypoints=websecure
       - traefik.http.services.pihole.loadbalancer.server.port=80
       - traefik.http.services.pihole.loadbalancer.healthcheck.path=/admin/login.php

--- a/planefinder/docker-compose.yaml
+++ b/planefinder/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
       - traefik.http.routers.planefinder.rule=Host(`planefinder.viewpoint.house`)
       - traefik.http.routers.planefinder.entrypoints=websecure
       - traefik.http.routers.planefinder.tls=true
+      - traefik.http.routers.planefinder.tls.certresolver=letsencrypt
       - traefik.http.services.planefinder.loadbalancer.server.port=30053
       - traefik.http.services.planefinder.loadbalancer.healthcheck.path=/
       - traefik.http.services.planefinder.loadbalancer.healthcheck.port=30053

--- a/predbat/docker-compose.yaml
+++ b/predbat/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
       - traefik.http.routers.predbat.rule=Host(`predbat.viewpoint.house`)
       - traefik.http.routers.predbat.entrypoints=websecure
       - traefik.http.routers.predbat.tls=true
+      - traefik.http.routers.predbat.tls.certresolver=letsencrypt
       - traefik.http.services.predbat.loadbalancer.server.port=5052
       - traefik.http.services.predbat.loadbalancer.healthcheck.path=/
       - traefik.http.services.predbat.loadbalancer.healthcheck.port=5052

--- a/radarr/docker-compose.yaml
+++ b/radarr/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
       - traefik.http.routers.radarr.rule=Host(`movies.viewpoint.house`)
       - traefik.http.routers.radarr.entrypoints=websecure
       - traefik.http.routers.radarr.tls=true
+      - traefik.http.routers.radarr.tls.certresolver=letsencrypt
       - traefik.http.services.radarr.loadbalancer.server.port=7878
       - traefik.http.services.radarr.loadbalancer.healthcheck.port=7878
       - traefik.http.services.radarr.loadbalancer.healthcheck.path=/

--- a/rss/docker-compose.yaml
+++ b/rss/docker-compose.yaml
@@ -85,6 +85,7 @@ services:
       - traefik.http.routers.freshrss.rule=Host(`rss.glasgownet.com`)
       - traefik.http.routers.freshrss.entrypoints=websecure
       - traefik.http.routers.freshrss.tls=true
+      - traefik.http.routers.freshrss.tls.certresolver=letsencrypt
       - traefik.http.services.freshrss.loadbalancer.server.port=80
       - traefik.http.services.freshrss.loadbalancer.healthcheck.path=/
       - traefik.http.services.freshrss.loadbalancer.healthcheck.port=80

--- a/scrutiny/docker-compose.yaml
+++ b/scrutiny/docker-compose.yaml
@@ -54,6 +54,7 @@ services:
       - traefik.http.routers.scrutiny-web.rule=Host(`scrutiny.viewpoint.house`)
       - traefik.http.routers.scrutiny-web.entrypoints=websecure
       - traefik.http.routers.scrutiny-web.tls=true
+      - traefik.http.routers.scrutiny-web.tls.certresolver=letsencrypt
       - traefik.http.services.scrutiny-web.loadbalancer.server.port=8080
       - traefik.http.services.scrutiny-web.loadbalancer.healthcheck.path=/api/health
       - traefik.http.services.scrutiny-web.loadbalancer.healthcheck.port=8080

--- a/social-stack/docker-compose.yaml
+++ b/social-stack/docker-compose.yaml
@@ -51,6 +51,7 @@ services:
       - traefik.http.routers.firefish.rule=Host(`social.glasgownet.com`) && !HeaderRegexp(`User-Agent`, `(?i)Applebot`)
       - traefik.http.routers.firefish.entrypoints=websecure
       - traefik.http.routers.firefish.tls=true
+      - traefik.http.routers.firefish.tls.certresolver=letsencrypt
       - traefik.http.services.firefish.loadbalancer.server.port=3000
       - traefik.http.services.firefish.loadbalancer.healthcheck.path=/
       - traefik.http.services.firefish.loadbalancer.healthcheck.port=3000

--- a/sonarr/docker-compose.yaml
+++ b/sonarr/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
       - traefik.http.routers.sonarr.rule=Host(`tv.viewpoint.house`)
       - traefik.http.routers.sonarr.entrypoints=websecure
       - traefik.http.routers.sonarr.tls=true
+      - traefik.http.routers.sonarr.tls.certresolver=letsencrypt
       - traefik.http.services.sonarr.loadbalancer.server.port=8989
       - traefik.http.services.sonarr.loadbalancer.healthcheck.port=8989
       - traefik.http.services.sonarr.loadbalancer.healthcheck.path=/

--- a/tdarr/docker-compose.yaml
+++ b/tdarr/docker-compose.yaml
@@ -60,6 +60,7 @@ services:
       - traefik.http.routers.tdarr.rule=Host(`tdarr.viewpoint.house`)
       - traefik.http.routers.tdarr.entrypoints=websecure
       - traefik.http.routers.tdarr.tls=true
+      - traefik.http.routers.tdarr.tls.certresolver=letsencrypt
       - traefik.http.services.tdarr.loadbalancer.server.port=8265
       - traefik.http.services.tdarr.loadbalancer.healthcheck.port=8265
       - traefik.http.services.tdarr.loadbalancer.healthcheck.path=/

--- a/unifi/docker-compose.yaml
+++ b/unifi/docker-compose.yaml
@@ -40,6 +40,7 @@ services:
       - traefik.http.routers.unifi-controller.rule=Host(`unifi.viewpoint.house`)
       - traefik.http.routers.unifi-controller.entrypoints=websecure
       - traefik.http.routers.unifi-controller.tls=true
+      - traefik.http.routers.unifi-controller.tls.certresolver=letsencrypt
       - traefik.http.services.unifi-controller.loadbalancer.server.port=8081
       - traefik.http.services.unifi-controller.loadbalancer.server.scheme=https
       # - traefik.http.services.unifi-controller.loadbalancer.healthcheck.path=/

--- a/uptime-kuma/docker-compose.yaml
+++ b/uptime-kuma/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
       - traefik.http.routers.uptime.rule=Host(`uptime.viewpoint.house`)
       - traefik.http.routers.uptime.entrypoints=websecure
       - traefik.http.routers.uptime.tls=true
+      - traefik.http.routers.uptime.tls.certresolver=letsencrypt
       - traefik.http.services.uptime.loadbalancer.server.port=3001
       - traefik.http.services.uptime.loadbalancer.healthcheck.path=/
       - traefik.http.services.uptime.loadbalancer.healthcheck.port=3001

--- a/wallabag/docker-compose.yaml
+++ b/wallabag/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       - traefik.http.routers.wallabag.rule=Host(`pocket.glasgownet.com`)
       - traefik.http.routers.wallabag.entrypoints=websecure
       - traefik.http.routers.wallabag.tls=true
+      - traefik.http.routers.wallabag.tls.certresolver=letsencrypt
       - traefik.http.services.wallabag.loadbalancer.server.port=80
       - traefik.http.services.wallabag.loadbalancer.healthcheck.path=/
       - traefik.http.services.wallabag.loadbalancer.healthcheck.port=80

--- a/warpgate/docker-compose.yaml
+++ b/warpgate/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
       - traefik.http.routers.warpgate.rule=Host(`warpgate.viewpoint.house`)
       - traefik.http.routers.warpgate.entrypoints=websecure
       - traefik.http.routers.warpgate.tls=true
+      - traefik.http.routers.warpgate.tls.certresolver=letsencrypt
       - traefik.http.services.warpgate.loadbalancer.server.port=9999
       # - traefik.http.services.warpgate.loadbalancer.healthcheck.path=/
       # - traefik.http.services.warpgate.loadbalancer.healthcheck.port=9999

--- a/zigbee2mqtt/docker-compose.yaml
+++ b/zigbee2mqtt/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       - traefik.http.routers.z2m.rule=Host(`z2m.viewpoint.house`)
       - traefik.http.routers.z2m.entrypoints=websecure
       - traefik.http.routers.z2m.tls=true
+      - traefik.http.routers.z2m.tls.certresolver=letsencrypt
       - traefik.http.services.z2m.loadbalancer.server.port=8080
       - traefik.http.services.z2m.loadbalancer.healthcheck.path=/
       - traefik.http.services.z2m.loadbalancer.healthcheck.port=8080


### PR DESCRIPTION
Ensure all Traefik-exposed services with TLS enabled have the `tls.certresolver=letsencrypt` configuration. This change addresses the absence of explicit certresolver settings for 45 services, enabling proper certificate requests.