### PR TITLE
Rename external network to traefik_proxy and add network-stack

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,9 +21,9 @@ This is a **Docker Compose-based home server infrastructure** repository contain
 **All volumes use NFS4 mounts** pointing to `172.24.32.5:/srv/nfs4/docker_nfs/<service>/` or `/media/Tank/` paths. This is critical for understanding volume configuration.
 
 ### Network Architecture
-- **Primary network**: `traefik_traefik_proxy` - External network for all web-accessible services
+- **Primary network**: `traefik_proxy` - External network for all web-accessible services
 - **Service-specific networks**: `homeautomation`, `monitoring`, `elastic`, etc.
-- Services requiring external network access **must** specify: `name: traefik_traefik_proxy` and `external: true`
+- Services requiring external network access **must** specify: `name: traefik_proxy` and `external: true`
 
 ### Multi-Host Deployment
 Three deployment targets controlled via `DOCKER_HOST` environment variable:
@@ -118,7 +118,7 @@ All services follow this pattern:
 networks:
   traefik_proxy:
     external: true
-    name: traefik_traefik_proxy
+    name: traefik_proxy
 
 volumes:
   service_data:
@@ -151,7 +151,7 @@ Services exposed via Traefik **must** include:
 - Entrypoint: `traefik.http.routers.<name>.entrypoints=web` or `websecure`
 - Service port: `traefik.http.services.<name>.loadbalancer.server.port=<port>`
 - For HTTPS: `traefik.http.routers.<name>.tls.certresolver=letsencrypt`
-- Network specification: `traefik.docker.network=traefik_traefik_proxy`
+- Network specification: `traefik.docker.network=traefik_proxy`
 
 ### Watchtower Auto-Update Labels
 Most services include: `com.centurylinklabs.watchtower.enable=true` for automatic updates
@@ -172,7 +172,7 @@ Services visible on homepage dashboard include:
 
 ### Compose Config Validation Quirks
 - **Missing .env files generate warnings but are not errors** - exit code is still 0
-- **Network name mismatches** cause: "invalid cluster node while attaching to network" - always use `name: traefik_traefik_proxy` for external networks
+- **Network name mismatches** cause: "invalid cluster node while attaching to network" - always use `name: traefik_proxy` for external networks
 - **Some services have multiple compose files** (e.g., traefik/docker-compose-deepcore.yaml, scrutiny/docker-compose-blackbird.yaml) for different deployment hosts
 
 ### Renovate Dependency Management
@@ -184,7 +184,7 @@ Services visible on homepage dashboard include:
 
 ### When Adding/Modifying Services:
 1. **Always validate compose syntax**: `docker compose -f <file> config --quiet`
-2. **Check for external network usage**: If exposing via Traefik, use `traefik_traefik_proxy` network with correct name
+2. **Check for external network usage**: If exposing via Traefik, use `traefik_proxy` network with correct name
 3. **Use NFS4 volumes**: Follow existing patterns for volume mounts pointing to 172.24.32.5
 4. **Add appropriate labels**: Traefik routing, Watchtower updates, Homepage dashboard
 5. **Consider deployment host**: Determine if service belongs on homeauto, blackbird, or deepcore

--- a/borg-ui/docker-compose.yaml
+++ b/borg-ui/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       - borg_ui_cache:/home/borg/.cache/borg
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.borg-ui-http.entrypoints=web
       - traefik.http.routers.borg-ui-http.rule=Host(`borg-ui.viewpoint.house`)
       - traefik.http.routers.borg-ui-http.middlewares=borg-ui-https

--- a/common/networks.yaml
+++ b/common/networks.yaml
@@ -2,7 +2,7 @@
 networks:
   traefik_proxy:
     external: true
-    name: traefik_traefik_proxy
+    name: traefik_proxy
   homeautomation:
     external: true
     name: homeautomation

--- a/core-stack/docker-compose.yaml
+++ b/core-stack/docker-compose.yaml
@@ -180,7 +180,7 @@ services:
       - traefik_proxy
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.meshtastic.rule=Host(`meshtastic.viewpoint.house`)
       - traefik.http.routers.meshtastic.entrypoints=web
       - traefik.http.services.meshtastic.loadbalancer.server.port=8080

--- a/dawarich/docker-compose.yaml
+++ b/dawarich/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
         restart: true
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.dawarich-http.entrypoints=web
       - traefik.http.routers.dawarich-http.rule=Host(`timeline.viewpoint.house`)
       - traefik.http.routers.dawarich-http.middlewares=dawarich-https

--- a/double-take/docker-compose.yaml
+++ b/double-take/docker-compose.yaml
@@ -1,7 +1,7 @@
 # networks:
 #   traefik_proxy:
 #     external: true
-#     name: traefik_traefik_proxy
+#     name: traefik_proxy
 #   homeautomation:
 #     external: true
 

--- a/elk-stack/docker-compose.yaml
+++ b/elk-stack/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - traefik_proxy
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.cerebro.rule=Host(`cerebro.viewpoint.house`)
       - traefik.http.routers.cerebro.entrypoints=websecure
       - traefik.http.routers.cerebro.tls=true
@@ -71,7 +71,7 @@ services:
       - traefik_proxy
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.elastichq.rule=Host(`elastichq.viewpoint.house`)
       - traefik.http.routers.elastichq.entrypoints=websecure
       - traefik.http.routers.elastichq.tls=true
@@ -313,7 +313,7 @@ services:
       ELASTICSEARCH_HOSTS: http://es01:9200
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.kibana01.rule=Host(`logs.viewpoint.house`)
       - traefik.http.routers.kibana01.entrypoints=websecure
       - traefik.http.routers.kibana01.tls=true

--- a/eplzones/docker-compose.yaml
+++ b/eplzones/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       retries: 5
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.EPLZones.rule=Host(`eplzones.viewpoint.house`)
       - traefik.http.routers.EPLZones.entrypoints=websecure
       - traefik.http.routers.EPLZones.tls=true

--- a/esphome/docker-compose.yaml
+++ b/esphome/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       # - ESPHOME_DASHBOARD_USE_PING=true
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.esphome-http.entrypoints=web
       - traefik.http.routers.esphome-http.rule=Host(`esphome.viewpoint.house`)
       - traefik.http.routers.esphome-http.middlewares=esphome-https

--- a/fr24feed/docker-compose.yaml
+++ b/fr24feed/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       retries: 5
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.fr24feed.rule=Host(`fr24feed.viewpoint.house`)
       - traefik.http.routers.fr24feed.entrypoints=websecure
       - traefik.http.routers.fr24feed.tls=true

--- a/frigate/docker-compose.yaml
+++ b/frigate/docker-compose.yaml
@@ -62,7 +62,7 @@ services:
       retries: 10
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.frigate-http.entrypoints=web
       - traefik.http.routers.frigate-http.rule=Host(`cctv.viewpoint.house`)
       - traefik.http.routers.frigate-http.middlewares=frigate-https

--- a/givtcp/docker-compose.yaml
+++ b/givtcp/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       retries: 5
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.givtcp.rule=Host(`givtcp.viewpoint.house`)
       - traefik.http.routers.givtcp.entrypoints=websecure
       - traefik.http.routers.givtcp.tls=true

--- a/ha-stack/docker-compose.yaml
+++ b/ha-stack/docker-compose.yaml
@@ -1,17 +1,10 @@
 ---
 
-networks:
-    traefik_proxy:
-      external: true
-      # Failure to provide the correct external network name results in:
-      # Error response from daemon: failed to set up container networking: invalid cluster node while attaching to network
-      name: traefik_traefik_proxy
-
-    homeautomation:
-      name: homeautomation
-
+# traefik_proxy and homeautomation are created by ../network-stack and consumed here
+# as external via ../common/networks.yaml.
 # Applications that are included here likely have dependencies on each other
 include:
+  - ../common/networks.yaml
   - ../home-assistant/docker-compose.yaml
   - ../double-take/docker-compose.yaml
   - ../frigate/docker-compose.yaml

--- a/home-assistant/docker-compose.yaml
+++ b/home-assistant/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     labels:
       # https://techoverflow.net/2022/03/27/how-to-fix-traefik-could-not-define-the-service-name-for-the-router-too-many-services/
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.ha.rule=Host(`viewpoint.house`) || Host(`172.24.32.13`)
       - traefik.http.routers.ha.entrypoints=haweb
       - traefik.http.routers.ha.service=ha

--- a/immich/docker-compose.yaml
+++ b/immich/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
       disable: false
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.immich-http.entrypoints=web
       - traefik.http.routers.immich-http.rule=Host(`immich.viewpoint.house`)
       - traefik.http.routers.immich-http.middlewares=immich-https

--- a/infisical/docker-compose.yaml
+++ b/infisical/docker-compose.yaml
@@ -79,7 +79,7 @@ services:
       - traefik_proxy
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.infisical-http.entrypoints=web
       - traefik.http.routers.infisical-http.rule=Host(`infisical.viewpoint.house`)
       - traefik.http.routers.infisical-http.middlewares=infisical-https

--- a/komodo/docker-compose.yaml
+++ b/komodo/docker-compose.yaml
@@ -104,7 +104,7 @@ services:
       - traefik.http.routers.komodo.entrypoints=websecure
       - traefik.http.routers.komodo.tls.certresolver=letsencrypt
       - traefik.http.services.komodo.loadbalancer.server.port=9120
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - homepage.group=Infrastructure
       - homepage.name=Komodo
       - homepage.href=https://komodo.viewpoint.house

--- a/matter-hub/docker-compose.yaml
+++ b/matter-hub/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - home-assistant-matter-hub:/data
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.matter-hub.rule=Host(`matter-hub.viewpoint.house`) || Host(`172.24.32.13`)
       - traefik.http.routers.matter-hub.entrypoints=web
       - traefik.http.services.matter-hub.loadbalancer.server.port=8482

--- a/monitoring-stack/docker-compose.yaml
+++ b/monitoring-stack/docker-compose.yaml
@@ -84,7 +84,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.swarm.network=traefik_proxy
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.librenms-http.entrypoints=web
       - traefik.http.routers.librenms-http.rule=Host(`nms.viewpoint.house`)
       - traefik.http.routers.librenms-http.middlewares=librenms-https

--- a/music-assistant/docker-compose.yaml
+++ b/music-assistant/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
       - LOG_LEVEL=info
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.music-http.entrypoints=web
       - traefik.http.routers.music-http.rule=Host(`music.viewpoint.house`)
       - traefik.http.routers.music-http.middlewares=music-https

--- a/nautobot/docker-compose.yaml
+++ b/nautobot/docker-compose.yaml
@@ -92,7 +92,7 @@ services:
     restart: unless-stopped
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.nautobot.rule=Host(`nautobot.viewpoint.house`)
       - traefik.http.routers.nautobot.entrypoints=websecure
       - traefik.http.routers.nautobot.tls=true

--- a/network-stack/docker-compose.yaml
+++ b/network-stack/docker-compose.yaml
@@ -1,0 +1,23 @@
+networks:
+  traefik_proxy:
+    name: traefik_proxy
+  homeautomation:
+    name: homeautomation
+
+services:
+  # Keepalive container attached to both networks so creation is guaranteed and the
+  # networks are never pruned while consumers are down.
+  network-stack:
+    image: alpine:latest
+    container_name: network-stack
+    command: sleep infinity
+    restart: unless-stopped
+    networks:
+      - traefik_proxy
+      - homeautomation
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: 3
+

--- a/node-red/docker-compose.yaml
+++ b/node-red/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
           condition: service_started
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.nodered-http.entrypoints=web
       - traefik.http.routers.nodered-http.rule=Host(`nodered.viewpoint.house`)
       - traefik.http.routers.nodered-http.middlewares=nodered-https

--- a/ollama/docker-compose.yaml
+++ b/ollama/docker-compose.yaml
@@ -94,7 +94,7 @@ services:
       - traefik_proxy
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.ollama-http.entrypoints=web
       - traefik.http.routers.ollama-http.rule=Host(`ollama.viewpoint.house`)
       - traefik.http.routers.ollama-http.middlewares=ollama-https

--- a/paperless/docker-compose.yaml
+++ b/paperless/docker-compose.yaml
@@ -84,7 +84,7 @@ services:
       - paperless
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.paperless-http.entrypoints=web
       - traefik.http.routers.paperless-http.rule=Host(`paperless.viewpoint.house`)
       - traefik.http.routers.paperless-http.middlewares=paperless-https

--- a/photoprism/docker-compose.yaml
+++ b/photoprism/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
       retries: 5
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.photos-http.entrypoints=web
       - traefik.http.routers.photos-http.rule=Host(`photos.viewpoint.house`)
       - traefik.http.routers.photos-http.middlewares=photos-https

--- a/phpmyadmin/docker-compose.yaml
+++ b/phpmyadmin/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - photoprism
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.phpmyadmin-http.rule=Host(`phpmyadmin.viewpoint.house`)
       - traefik.http.routers.phpmyadmin-http.entrypoints=web
       - traefik.http.routers.phpmyadmin-http.middlewares=phpmyadmin-https

--- a/piaware/docker-compose.yaml
+++ b/piaware/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       retries: 5
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.piaware.rule=Host(`piaware.viewpoint.house`)
       - traefik.http.routers.piaware.entrypoints=websecure
       - traefik.http.routers.piaware.tls=true

--- a/planefinder/docker-compose.yaml
+++ b/planefinder/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
         tag: "{{.Name}}"
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.planefinder.rule=Host(`planefinder.viewpoint.house`)
       - traefik.http.routers.planefinder.entrypoints=websecure
       - traefik.http.routers.planefinder.tls=true

--- a/predbat/docker-compose.yaml
+++ b/predbat/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
           condition: service_healthy
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.predbat.rule=Host(`predbat.viewpoint.house`)
       - traefik.http.routers.predbat.entrypoints=websecure
       - traefik.http.routers.predbat.tls=true

--- a/radarr/docker-compose.yaml
+++ b/radarr/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       # - recyclarr
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.radarr-http.entrypoints=web
       - traefik.http.routers.radarr-http.rule=Host(`movies.viewpoint.house`)
       - traefik.http.routers.radarr-http.middlewares=radarr-https

--- a/scrutiny/docker-compose.yaml
+++ b/scrutiny/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
       start_period: 10s
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.scrutiny-web-http.entrypoints=web
       - traefik.http.routers.scrutiny-web-http.rule=Host(`scrutiny.viewpoint.house`)
       - traefik.http.routers.scrutiny-web-http.middlewares=scrutiny-web-https

--- a/selenium/docker-compose.yaml
+++ b/selenium/docker-compose.yaml
@@ -1,10 +1,6 @@
 ---
-networks:
-  traefik_proxy:
-    external: true
-    name: traefik_traefik_proxy
-  homeautomation:
-    external: true
+include:
+  - ../common/networks.yaml
 
 services:
   selenium:
@@ -17,7 +13,7 @@ services:
     restart: unless-stopped
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.selenium-http.entrypoints=web
       - traefik.http.routers.selenium-http.rule=Host(`selenium.viewpoint.house`)
       - traefik.http.routers.selenium-http.middlewares=selenium-https

--- a/sonarr/docker-compose.yaml
+++ b/sonarr/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       # - recyclarr
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.sonarr-http.entrypoints=web
       - traefik.http.routers.sonarr-http.rule=Host(`tv.viewpoint.house`)
       - traefik.http.routers.sonarr-http.middlewares=sonarr-https

--- a/traefik/docker-compose.yaml
+++ b/traefik/docker-compose.yaml
@@ -1,9 +1,8 @@
 ---
 
-networks:
-  traefik_proxy:
-    # driver: overlay
-    # driver: bridge
+# traefik_proxy is created by ../network-stack and consumed here as external.
+include:
+  - ../common/networks.yaml
 
 volumes:
 

--- a/up.sh
+++ b/up.sh
@@ -51,9 +51,9 @@ docker compose -f piaware/docker-compose.yaml up -d
 docker compose -f planefinder/docker-compose.yaml up -d
 docker compose -f fr24feed/docker-compose.yaml up -d
 
-### PHPMyAdmin needs access to other services' networks
+### PHPMyAdmin and PGAdmin need access to other services' networks
 docker compose -f phpmyadmin/docker-compose.yaml up -d
-
+docker compose -f pgadmin/docker-compose.yaml up -d
 
 echo "----- Deploying to ADS-B receiver (172.24.32.11) -----"
 export DOCKER_HOST=ssh://bagpuss@172.24.32.11

--- a/up.sh
+++ b/up.sh
@@ -2,6 +2,7 @@ echo "----- Deploying to homeauto -----"
 export DOCKER_HOST=ssh://bagpuss@172.24.32.13
 
 docker compose -f core-stack/docker-compose.yaml up -d
+docker compose -f network-stack/docker-compose.yaml up -d  # creates shared traefik_proxy + homeautomation networks
 docker compose -f traefik/docker-compose.yaml up -d
 docker compose -f infisical/docker-compose.yaml up -d
 docker compose -f unifi/docker-compose.yaml up -d

--- a/warpgate/docker-compose.yaml
+++ b/warpgate/docker-compose.yaml
@@ -1,8 +1,6 @@
 ---
-networks:
-  traefik_proxy:
-    external: true
-    name: traefik_traefik_proxy
+include:
+  - ../common/networks.yaml
 
 volumes:
   warpgate_data:
@@ -27,7 +25,7 @@ services:
       - warpgate_data:/data
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.warpgate-http.entrypoints=web
       - traefik.http.routers.warpgate-http.rule=Host(`warpgate.viewpoint.house`)
       - traefik.http.routers.warpgate-http.middlewares=warpgate-https

--- a/zigbee2mqtt/docker-compose.yaml
+++ b/zigbee2mqtt/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - homeautomation
     labels:
       - traefik.enable=true
-      - traefik.docker.network=traefik_traefik_proxy
+      - traefik.docker.network=traefik_proxy
       - traefik.http.routers.z2m-http.entrypoints=web
       - traefik.http.routers.z2m-http.rule=Host(`z2m.viewpoint.house`)
       - traefik.http.routers.z2m-http.middlewares=z2m-https


### PR DESCRIPTION
## Summary
- Rename the shared external Docker network from `traefik_traefik_proxy` to `traefik_proxy` across all service compose files and Traefik `traefik.docker.network` labels.
- Add a new `network-stack/` compose that creates the shared `traefik_proxy` and `homeautomation` networks, with a keepalive container so the networks are guaranteed to exist and are never pruned while consumers are down.
- Convert `traefik`, `ha-stack`, `selenium`, and `warpgate` to consume the shared networks as external via `common/networks.yaml` (`include:`) instead of declaring them inline.
- Add `network-stack` to `up.sh` so the shared networks are created early in the homeauto deploy.
- Update `.github/copilot-instructions.md` to reflect the new network name.

## Notes
- The keepalive `network-stack` container is an `alpine sleep infinity` attached to both networks purely to anchor them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)